### PR TITLE
Maintain preexisting filter style on the body element

### DIFF
--- a/src/content-script.js
+++ b/src/content-script.js
@@ -1,5 +1,15 @@
+const existingFilter = getComputedStyle(document.body).filter.replace('none', '');
+
 function setFilter(value) {
-  document.body.style.filter = value;
+  if (value === '') {
+    document.body.style.filter = existingFilter;
+    return;
+  }
+
+  const restOfTheFilters = existingFilter
+    .replace(/grayscale\([\d\.]+\)/, '').replace(/sepia\([\d\.]+\)/, '') // Remove grayscale and sepia filters
+    .replace(/\s+/g, ' ').trim(); // Remove extra spaces
+  document.body.style.filter = [restOfTheFilters, value].join(' ');
 }
 
 function handleFilter() {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Grayscale Bro",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Grayscale browsing",
   "homepage_url": "https://github.com/rewkha/firefox-grayscale",
   "icons": {


### PR DESCRIPTION
Issue:
 - For sites that are not in the store, or are excluded, any filters set on the body are stripped
 - For sites that are in store, or all sites when the configuration is on all, other filter values get replaced completely.

This will allow existing filters to exist on websites for both grayscale-d sites and all the rest.